### PR TITLE
Add a license

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,6 @@ src/MSBuild.Sdk.SqlProj/tools/
 
 # Ignore Mac specific files
 .DS_Store
+
+# Ignore LICENSE.txt files (needed to pack License into NuGet packages)
+LICENSE.txt

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020 Mark Iannucci
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Mark Iannucci
+Copyright (c) 2020 jmezach
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
+++ b/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj
@@ -26,6 +26,7 @@
         packagetype=MSBuildSdk
       </NuspecProperties>
     </PropertyGroup>
+    <Copy SourceFiles="../../LICENSE" DestinationFiles="LICENSE.txt" />
   </Target>
 
   <Target Name="IncludeBuildDacpacTool" AfterTargets="Build">

--- a/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.nuspec
+++ b/src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.nuspec
@@ -9,6 +9,7 @@
     <copyright>$copyright$</copyright>
     <projectUrl>$projecturl$</projectUrl>
     <tags>$tags$</tags>
+    <license type="file">LICENSE.txt</license>
     <packageTypes>
       <packageType name="$packagetype$" />
     </packageTypes>
@@ -17,5 +18,6 @@
   <files>
     <file src="Sdk\**" target="Sdk" />
     <file src="tools\**" target="tools" />
+    <file src="LICENSE.txt" target="LICENSE.txt" />
   </files>
 </package>


### PR DESCRIPTION
Hi @jmezach , this looks like something we'd really like to use for some of our internal projects at Denver Health.  Any chance I can get you to add a license?  I suggested MIT simply because it is well known and permissive which I think may be consistent with what [you wrote](https://jmezach.github.io/post/introducing-msbuild-sdk-sqlproj/).

Please feel free to squash on completion since I didn't realize that the GitHub License file would automatically include my name.