### PR TITLE
Add command line support for adding SqlCmdVariables

### DIFF
--- a/src/BuildDacpac/PackageBuilderOptions.cs
+++ b/src/BuildDacpac/PackageBuilderOptions.cs
@@ -1,0 +1,17 @@
+﻿using System.IO;
+using Microsoft.SqlServer.Dac.Model;
+
+namespace MSBuild.Sdk.SqlProj.BuildDacpac
+{
+    public class PackageBuilderOptions
+    {
+        public string Name { get; set; }
+        public string Version { get; set; }
+        public FileInfo Output { get; set; }
+        public SqlServerVersion SqlServerVersion { get; set; }
+        public FileInfo[] Input { get; set; }
+        public FileInfo[] Reference { get; set; }
+        public string[] Property { get; set; }
+        public string[] SqlCmdVar { get; set; }
+    }
+}

--- a/src/BuildDacpac/Program.cs
+++ b/src/BuildDacpac/Program.cs
@@ -19,46 +19,56 @@ namespace MSBuild.Sdk.SqlProj.BuildDacpac
                 new Option<FileInfo[]>(new string[] { "--input", "-i" }, "Input file name(s)"),
                 new Option<FileInfo[]>(new string[] { "--reference", "-r" }, "Reference(s) to include"),
                 new Option<string[]>(new string[] { "--property", "-p" }, "Properties to be set on the model"),
+                new Option<string[]>(new string[] { "--sqlcmdvar", "-sc" }, "SqlCmdVariable(s) to include"),
             };
 
             rootCommand.Description = "Command line tool for generating a SQL Server Data-Tier Application Framework package (dacpac)";
-            rootCommand.Handler = CommandHandler.Create<string, string, FileInfo, SqlServerVersion, FileInfo[], FileInfo[], string[]>(BuildDacpac);
+            rootCommand.Handler = CommandHandler.Create<PackageBuilderOptions>(BuildDacpac);
 
             return await rootCommand.InvokeAsync(args);
         }
 
-        private static int BuildDacpac(string name, string version, FileInfo output, SqlServerVersion sqlServerVersion, FileInfo[] input, FileInfo[] reference, string[] property)
+        private static int BuildDacpac(PackageBuilderOptions options)
         {
             // Set metadata for the package
             using var packageBuilder = new PackageBuilder();
-            packageBuilder.SetMetadata(name, version);
+            packageBuilder.SetMetadata(options.Name, options.Version);
 
             // Set properties on the model (if defined)
-            if (property != null)
+            if (options.Property != null)
             {
-                foreach (var propertyValue in property)
+                foreach (var propertyValue in options.Property)
                 {
                     string[] keyValuePair = propertyValue.Split('=', 2);
                     packageBuilder.SetProperty(keyValuePair[0], keyValuePair[1]);
                 }
             }
 
-            // Build the empty model for te targetted SQL Server version
-            packageBuilder.UsingVersion(sqlServerVersion);
+            // Add SqlCmdVariables to the package (if defined)
+            if (options.SqlCmdVar != null)
+            {
+                foreach (var sqlcmdVariable in options.SqlCmdVar)
+                {
+                    packageBuilder.AddSqlCmdVariable(sqlcmdVariable);
+                }
+            }
+
+            // Build the empty model for the target SQL Server version
+            packageBuilder.UsingVersion(options.SqlServerVersion);
 
             // Add references to the model
-            if (reference != null)
+            if (options.Reference != null)
             {
-                foreach (var referenceFile in reference)
+                foreach (var referenceFile in options.Reference)
                 {
                     packageBuilder.AddReference(referenceFile);
                 }
             }
 
             // Add input files
-            if (input != null)
+            if (options.Input != null)
             {
-                foreach (var inputFile in input)
+                foreach (var inputFile in options.Input)
                 {
                     packageBuilder.AddInputFile(inputFile);
                 }
@@ -71,8 +81,9 @@ namespace MSBuild.Sdk.SqlProj.BuildDacpac
             }
 
             // Save the package to disk
-            packageBuilder.SaveToDisk(output);
+            packageBuilder.SaveToDisk(options.Output);
             return 0;
         }
+
     }
 }


### PR DESCRIPTION
part of #6 (implements https://github.com/dotnet/command-line-api/issues/458 )

@jmezach I leave the MsBuild changes to you, I have no idea where to start (or end, for that matter)

Tested by running "dotnet build" against the test projects.