### PR TITLE
Implement support for SqlCmd variables

### DIFF
--- a/src/BuildDacpac/BuildDacpac.csproj
+++ b/src/BuildDacpac/BuildDacpac.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4573.2" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20158.1" />
+    <PackageReference Include="Microsoft.SqlServer.DACFX" Version="150.4769.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20214.1" />
   </ItemGroup>
 
 </Project>

--- a/src/BuildDacpac/Program.cs
+++ b/src/BuildDacpac/Program.cs
@@ -44,15 +44,6 @@ namespace MSBuild.Sdk.SqlProj.BuildDacpac
                 }
             }
 
-            // Add SqlCmdVariables to the package (if defined)
-            if (options.SqlCmdVar != null)
-            {
-                foreach (var sqlcmdVariable in options.SqlCmdVar)
-                {
-                    packageBuilder.AddSqlCmdVariable(sqlcmdVariable);
-                }
-            }
-
             // Build the empty model for the target SQL Server version
             packageBuilder.UsingVersion(options.SqlServerVersion);
 
@@ -62,6 +53,15 @@ namespace MSBuild.Sdk.SqlProj.BuildDacpac
                 foreach (var referenceFile in options.Reference)
                 {
                     packageBuilder.AddReference(referenceFile);
+                }
+            }
+
+            // Add SqlCmdVariables to the package (if defined)
+            if (options.SqlCmdVar != null)
+            {
+                foreach (var sqlcmdVariable in options.SqlCmdVar)
+                {
+                    packageBuilder.AddSqlCmdVariable(sqlcmdVariable);
                 }
             }
 

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -21,7 +21,7 @@
   <Import Project="$(CustomBeforeNoTargetsProps)" Condition=" '$(CustomBeforeNoTargetsProps)' != '' And Exists('$(CustomBeforeNoTargetsProps)') " />
 
   <PropertyGroup>
-    <!-- Disable default Compile and EmbeddedResource items for NoTargets projects -->
+    <!-- Disable default Compile and EmbeddedResource items for MSBuild.Sdk.SqlProj projects -->
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
     <NoPackageAnalysis>True</NoPackageAnalysis>

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -142,10 +142,11 @@
       <ReferenceArguments>@(DacpacReference->'-r &quot;%(PhysicalLocation)\tools\%(Identity).dacpac&quot;', ' ')</ReferenceArguments>
       <InputFileArguments>@(Content->'-i &quot;%(FullPath)&quot;', ' ')</InputFileArguments>
       <PropertyArguments>@(PropertyNames->'-p %(Identity)=%(PropertyValue)', ' ')</PropertyArguments>
+      <SqlCmdVariableArguments>@(SqlCmdVariable->'-sc %(Identity)', ' ')</SqlCmdVariableArguments>
       <BuildDacpacTfm>netcoreapp$(BundledNETCoreAppTargetFrameworkVersion)</BuildDacpacTfm>
     </PropertyGroup>
     <!-- Run it, except during design-time builds -->
-    <Exec Command="dotnet $(MSBuildThisFileDirectory)../tools/$(BuildDacpacTfm)/BuildDacpac.dll $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(PropertyArguments)"
+    <Exec Command="dotnet $(MSBuildThisFileDirectory)../tools/$(BuildDacpacTfm)/BuildDacpac.dll $(OutputPathArgument) $(MetadataArguments) $(SqlServerVersionArgument) $(InputFileArguments) $(ReferenceArguments) $(SqlCmdVariableArguments) $(PropertyArguments)"
           Condition="'$(DesignTimeBuild)' != 'true' AND '$(BuildingProject)' == 'true'"/>
 
     <!-- Copy any referenced .dacpac packages to the output folder -->

--- a/test/TestProjectWithSqlCmdVariables/TestProjectWithSqlCmdVariables.csproj
+++ b/test/TestProjectWithSqlCmdVariables/TestProjectWithSqlCmdVariables.csproj
@@ -1,0 +1,16 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <SqlCmdVariable Include="MySqlCmdVariable">
+      <DefaultValue>DefaultValue</DefaultValue>
+      <Value>$(SqlCmdVar__1)</Value>
+    </SqlCmdVariable>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>


### PR DESCRIPTION
This is the last stretch towards implementing #6. It adds the necessary wiring in the MSBuild stuff to pass the SqlCmd variables defined in the project file to the command line tool, which can then add the requested variables to the `.dacpac`.