### PR TITLE
chore(deps): bump Microsoft.SqlServer.DacFx from 170.1.61 to 170.2.70

### DIFF
--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.1.61" />
+    <PackageReference Include="Microsoft.SqlServer.DacFx" Version="170.2.70" />
     <PackageReference Include="NuGet.Versioning" Version="6.14.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.NamingConventionBinder" Version="2.0.0-beta4.22272.1" />


### PR DESCRIPTION
Updated the DacFx package reference to the latest patch version to incorporate upstream fixes and improvements.

- Microsoft.SqlServer.DacFx: 170.1.61 → 170.2.70
- No other dependencies or build settings changed