### PR TITLE
build(tests): enable nullable refs and bump LangVersion to C# 12

### DIFF
--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -5,7 +5,8 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MSBuild.Sdk.SqlProj.DacpacTool.Tests</AssemblyName>
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool.Tests</RootNamespace>
-    <LangVersion>9.0</LangVersion>
+    <LangVersion>12</LangVersion>
+    <Nullable>enable</Nullable>
     <NuGetAudit>false</NuGetAudit>
     <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>


### PR DESCRIPTION
enable nullable refs and bump LangVersion to C# 12 in test project

- Set <LangVersion> to 12 (was 9.0)
- Enable nullable reference types: <Nullable>enable</Nullable>
- No changes to target frameworks, packages, or test settings

Aims to modernize the test project to current C# features and improve null-safety.