### PR TITLE
Set property to not generate documentation file

### DIFF
--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.props
@@ -12,6 +12,9 @@
     <TargetExt>.dacpac</TargetExt>
     <EnableSdkContainerSupport Condition="'$(EnableSdkContainerSupport)' == ''">true</EnableSdkContainerSupport>
     <SqlPackageDownloadUrl>https://aka.ms/sqlpackage-linux</SqlPackageDownloadUrl>
+
+    <!-- Setting this here so that we won't try to generate a documentation file and then fail on publish since it doesn't exist -->
+    <GenerateDocumentationFile>False</GenerateDocumentationFile>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This sets a property in the `Sdk.props` to avoid attempting to generate a documentation file and then failing on publish since it doesn't exist.

Fixes #847 