### PR TITLE
feat: support item-based CodeAnalysisRule config

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,60 @@ A xml file with the analysis results is created in the output folder.
 
 The optional `CodeAnalysisRules` property allows you to disable individual rules or groups of rules for the entire project.
 
+If you have many analyzer rule adjustments, you can also declare them as items instead of a single semicolon-delimited property value:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/4.0.0">
+  <PropertyGroup>
+    <RunSqlCodeAnalysis>True</RunSqlCodeAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRD*</RuleId>
+      <Action>Suppress</Action>
+      <Explanation>suppress globally for some good reason</Explanation> <!-- optional explanation -->
+    </CodeAnalysisRule>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRN0005</RuleId>
+      <Action>Error</Action>
+      <Explanation>this type of violoation should break the build</Explanation> <!-- optional explanation -->
+    </CodeAnalysisRule>
+  </ItemGroup>
+</Project>
+```
+
+`Include` is only a placeholder required by MSBuild. The SDK uses `RuleId` and `Action`. `Explanation` is optional and is ignored by the SDK, so you can use it as a maintainer note in the project file.
+
+Supported `Action` values are:
+
+- `Suppress` to disable the specified rule
+- `Error` to report the specified rule as an error
+
+Use the `RuleId` element to define the rule name or wildcard pattern. For example, `SqlServer.Rules.SRD*` matches all rules with that prefix.
+
+If both `CodeAnalysisRules` and `CodeAnalysisRule` items are used, they are combined.
+
+You can use `+!*` in `CodeAnalysisRules` to treat all analyzer findings as errors, then add `CodeAnalysisRule` items to suppress specific rules:
+
+```xml
+<Project Sdk="MSBuild.Sdk.SqlProj/4.0.0">
+  <PropertyGroup>
+    <RunSqlCodeAnalysis>True</RunSqlCodeAnalysis>
+    <CodeAnalysisRules>+!*</CodeAnalysisRules> <!-- treat all analyzer findings as errors -->
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRD0004</RuleId>
+      <Action>Suppress</Action>
+    </CodeAnalysisRule>
+  </ItemGroup>
+</Project>
+```
+
+If the same rule is configured as both `Suppress` and `Error`, suppression takes precedence.
+
 Starting with version 3.0.0 of the SDK, you can also disable rules per file. Add a `StaticCodeAnalysis.SuppressMessages.xml` file to the project root, with contents similar to this:
 
 ```xml

--- a/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
+++ b/src/MSBuild.Sdk.SqlProj/Sdk/Sdk.targets
@@ -180,9 +180,40 @@
   </Target>
 
   <!--
+    Builds the effective code analysis rule expression from the CodeAnalysisRules property and any CodeAnalysisRule items.
+  -->
+  <Target Name="ComputeCodeAnalysisRules">
+    <ItemGroup>
+      <_CodeAnalysisRuleExpressions Include="@(CodeAnalysisRule)"
+                                    Condition="'%(CodeAnalysisRule.RuleId)' != '' and ('%(CodeAnalysisRule.Action)' == '' Or '%(CodeAnalysisRule.Action)' == 'Suppress')">
+        <Expression>-%(CodeAnalysisRule.RuleId)</Expression>
+      </_CodeAnalysisRuleExpressions>
+      <_CodeAnalysisRuleExpressions Include="@(CodeAnalysisRule)"
+                                    Condition="'%(CodeAnalysisRule.RuleId)' != '' and '%(CodeAnalysisRule.Action)' == 'Error'">
+        <Expression>+!%(CodeAnalysisRule.RuleId)</Expression>
+      </_CodeAnalysisRuleExpressions>
+      <_CodeAnalysisRuleExpressions Include="@(CodeAnalysisRule)"
+                                    Condition="'%(CodeAnalysisRule.RuleId)' == '' and ('%(CodeAnalysisRule.Action)' == '' Or '%(CodeAnalysisRule.Action)' == 'Suppress')">
+        <Expression>-%(CodeAnalysisRule.Identity)</Expression>
+      </_CodeAnalysisRuleExpressions>
+      <_CodeAnalysisRuleExpressions Include="@(CodeAnalysisRule)"
+                                    Condition="'%(CodeAnalysisRule.RuleId)' == '' and '%(CodeAnalysisRule.Action)' == 'Error'">
+        <Expression>+!%(CodeAnalysisRule.Identity)</Expression>
+      </_CodeAnalysisRuleExpressions>
+    </ItemGroup>
+
+    <PropertyGroup>
+      <CodeAnalysisRulesFromItems>@(_CodeAnalysisRuleExpressions->'%(Expression)', ';')</CodeAnalysisRulesFromItems>
+      <EffectiveCodeAnalysisRules Condition="'$(CodeAnalysisRules)' != '' And '$(CodeAnalysisRulesFromItems)' != ''">$(CodeAnalysisRules);$(CodeAnalysisRulesFromItems)</EffectiveCodeAnalysisRules>
+      <EffectiveCodeAnalysisRules Condition="'$(EffectiveCodeAnalysisRules)' == '' And '$(CodeAnalysisRules)' != ''">$(CodeAnalysisRules)</EffectiveCodeAnalysisRules>
+      <EffectiveCodeAnalysisRules Condition="'$(EffectiveCodeAnalysisRules)' == '' And '$(CodeAnalysisRulesFromItems)' != ''">$(CodeAnalysisRulesFromItems)</EffectiveCodeAnalysisRules>
+    </PropertyGroup>
+  </Target>
+
+  <!--
     Performs the actual compilation of the input files (*.sql) into a .dacpac package by calling into a command line tool to do the actual work.
   -->
-  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles"
+  <Target Name="CoreCompile" DependsOnTargets="ValidateEnvironment;ResolveDatabaseReferences;GetIncludedFiles;ComputeCodeAnalysisRules"
           Inputs="@(Content);@(PreDeploy);@(PostDeploy);@(RefactorLog);$(IncludedFiles);$(ProjectPath)" Outputs="$(TargetPath)">
     <ItemGroup>
       <!-- Get the values for known model properties specified in the project file -->
@@ -232,7 +263,7 @@
       <RefactorLogScriptArgument>@(RefactorLog->'--refactorlog &quot;%(Identity)&quot;', ' ')</RefactorLogScriptArgument>
       <RunSqlCodeAnalysisArgument Condition="'$(RunSqlCodeAnalysis)' == 'True'">-an</RunSqlCodeAnalysisArgument>
       <CodeAnalysisAssemblyLookupPathsArgument Condition="'$(RunSqlCodeAnalysis)' == 'True'">@(Analyzer->'-aa &quot;%(Identity)&quot;', ' ')</CodeAnalysisAssemblyLookupPathsArgument>
-      <CodeAnalysisRulesArgument Condition="'$(CodeAnalysisRules)'!=''">-ar &quot;$(CodeAnalysisRules)&quot;</CodeAnalysisRulesArgument>
+      <CodeAnalysisRulesArgument Condition="'$(EffectiveCodeAnalysisRules)'!=''">-ar &quot;$(EffectiveCodeAnalysisRules)&quot;</CodeAnalysisRulesArgument>
       <DebugArgument Condition="'$(MSBuildSdkSqlProjDebug)' == 'True'">--debug</DebugArgument>
       <TreatTSqlWarningsAsErrorsArgument Condition="'$(TreatTSqlWarningsAsErrors)' == 'True' Or ('$(TreatWarningsAsErrors)' == 'True' And '$(TreatTSqlWarningsAsErrors)' == '')">--warnaserror</TreatTSqlWarningsAsErrorsArgument>
       <GenerateCreateScriptArgument Condition="'$(GenerateCreateScript)' == 'True'">--generatecreatescript</GenerateCreateScriptArgument>

--- a/test/DacpacTool.Tests/CodeAnalysisRuleItemTests.cs
+++ b/test/DacpacTool.Tests/CodeAnalysisRuleItemTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Shouldly;
+
+namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
+{
+    [TestClass]
+    public class CodeAnalysisRuleItemTests
+    {
+        [TestMethod]
+        public void Build_TranslatesCodeAnalysisRuleItemsIntoEffectiveCodeAnalysisRules()
+        {
+            var rules = BuildProjectAndReadEffectiveRules("TestProjectWithCodeAnalysisRuleItems");
+
+            rules.ShouldBe("-SqlServer.Rules.SRD*;+!SqlServer.Rules.SRN0005");
+        }
+
+        [TestMethod]
+        public void Build_CombinesLegacyCodeAnalysisRulesWithCodeAnalysisRuleItems()
+        {
+            var rules = BuildProjectAndReadEffectiveRules("TestProjectWithCodeAnalysisRuleItemsAndProperty");
+
+            rules.ShouldBe("-Smells.*;+!SqlServer.Rules.SRD0002;-SqlServer.Rules.SRD*;+!SqlServer.Rules.SRN0005");
+        }
+
+        [TestMethod]
+        public void Build_CombinesGlobalWildcardErrorsWithSuppressedCodeAnalysisRuleItems()
+        {
+            var rules = BuildProjectAndReadEffectiveRules("TestProjectWithCodeAnalysisRuleItemsAndGlobalError");
+
+            rules.ShouldBe("+!*;-SqlServer.Rules.SRD0004");
+        }
+
+        private static string BuildProjectAndReadEffectiveRules(string projectName)
+        {
+            var repoRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+            var projectDirectory = Path.Combine(repoRoot, "test", projectName);
+            var projectPath = Path.Combine(projectDirectory, $"{projectName}.csproj");
+            var outputPath = Path.Combine(Path.GetTempPath(), $"{projectName}.{Guid.NewGuid():N}.effective-code-analysis-rules.txt");
+
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "dotnet",
+                Arguments = $"msbuild \"{projectPath}\" /restore /nologo /t:WriteEffectiveCodeAnalysisRules /p:EffectiveCodeAnalysisRulesOutputFile=\"{outputPath}\"",
+                WorkingDirectory = projectDirectory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+
+            using var process = Process.Start(startInfo);
+            process.ShouldNotBeNull();
+
+            var standardOutput = process.StandardOutput.ReadToEnd();
+            var standardError = process.StandardError.ReadToEnd();
+            process.WaitForExit();
+
+            process.ExitCode.ShouldBe(0, standardOutput + Environment.NewLine + standardError);
+
+            File.Exists(outputPath).ShouldBeTrue("Expected MSBuild fixture to write the effective code analysis rules file.");
+            try
+            {
+                return File.ReadAllText(outputPath)
+                    .Replace("\r\n", ";")
+                    .Replace("\n", ";")
+                    .Trim(';', ' ', '\r', '\n', '\t');
+            }
+            finally
+            {
+                File.Delete(outputPath);
+            }
+        }
+    }
+}

--- a/test/DacpacTool.Tests/PackageAnalyzerTests.cs
+++ b/test/DacpacTool.Tests/PackageAnalyzerTests.cs
@@ -127,6 +127,137 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
         }
 
         [TestMethod]
+        public void RunsAnalyzerWithWildcardOverrides_CaseInsensitivePrefixes()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "+!sqlserver.rules.srd*");
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.Count(l => l.Contains("): Error ")).ShouldBe(2);
+            testConsole.Lines.ShouldContain("proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
+            testConsole.Lines.ShouldContain("-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzerWithWildcardSuppressions_CaseInsensitivePrefixes()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "-sqlserver.rules.srd*");
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.Any(l => l.Contains("SRD0006")).ShouldBeFalse();
+            testConsole.Lines.Any(l => l.Contains("SRD0002")).ShouldBeFalse();
+            testConsole.Lines.Any(l => l.Contains("Error")).ShouldBeFalse();
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        [DataRow("+!SqlServer.Rules.SRD0006", 1, "proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.",      true)]
+        [DataRow("+!SqlServer.Rules.SRD*",    2, "proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.",      true)]
+        [DataRow("+!SqlServer.Rules.SRD*",    2, "-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.", true)]
+        [DataRow("-SqlServer.Rules.SRD0006",  0, "proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.",      false)]
+        [DataRow("-SqlServer.Rules.SRD*",     0, "SRD0002",                                                                       false)]
+        public void RunsAnalyzerWithRuleSeverityOverrides_DataDriven(string overrideRules, int expectedErrorCount, string expectedOutputLine, bool expectContainsLine)
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, overrideRules);
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            if (expectContainsLine)
+            {
+                testConsole.Lines.Any(l => l.Contains(expectedOutputLine)).ShouldBeTrue();
+            }
+            else
+            {
+                testConsole.Lines.Any(l => l.Contains(expectedOutputLine)).ShouldBeFalse();
+            }
+
+            testConsole.Lines.Count(l => l.Contains("): Error ")).ShouldBe(expectedErrorCount);
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithMultipleWarningToErrorOverridesInSingleExpression()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "+!SqlServer.Rules.SRD0006;+!SqlServer.Rules.SRD0002;+!Smells.SML005");
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain("proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
+            testConsole.Lines.ShouldContain("-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.");
+            testConsole.Lines.Any(l => l.Contains("): Error SML005 : Smells : Avoid use of 'Select *'")).ShouldBeTrue();
+            testConsole.Lines.Count(l => l.Contains("): Error ")).ShouldBe(3);
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithGlobalWildcardErrorsAndSpecificSuppression()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "+!*;-SqlServer.Rules.SRD0006");
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.Any(l => l.Contains("SRD0006")).ShouldBeFalse();
+            testConsole.Lines.ShouldContain("-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithConflictingSuppressAndErrorForSameRule_SuppressionWins()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var result = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "+!SqlServer.Rules.SRD0006;-SqlServer.Rules.SRD0006");
+
+            // Act
+            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.Any(l => l.Contains("SRD0006")).ShouldBeFalse();
+            testConsole.Lines.Any(l => l.Contains("): Error SRD0006")).ShouldBeFalse();
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+        }
+
+        [TestMethod]
         public void RunsAnalyzerWithoutAdditionalAnalyzers()
         {
             // Arrange

--- a/test/TestProjectWithCodeAnalysisRuleItems/TestProjectWithCodeAnalysisRuleItems.csproj
+++ b/test/TestProjectWithCodeAnalysisRuleItems/TestProjectWithCodeAnalysisRuleItems.csproj
@@ -1,0 +1,32 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+    <RunSqlCodeAnalysis>true</RunSqlCodeAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRD*</RuleId>
+      <Action>Suppress</Action>
+      <Explanation>test wildcard suppression</Explanation>
+    </CodeAnalysisRule>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRN0005</RuleId>
+      <Action>Error</Action>
+    </CodeAnalysisRule>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+
+  <Target Name="WriteEffectiveCodeAnalysisRules" DependsOnTargets="ComputeCodeAnalysisRules">
+    <PropertyGroup>
+      <EffectiveCodeAnalysisRulesOutputFile Condition="'$(EffectiveCodeAnalysisRulesOutputFile)' == ''">$(IntermediateOutputPath)effective-code-analysis-rules.txt</EffectiveCodeAnalysisRulesOutputFile>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(EffectiveCodeAnalysisRulesOutputFile)"
+                      Overwrite="true"
+                      Lines="$(EffectiveCodeAnalysisRules)" />
+  </Target>
+</Project>

--- a/test/TestProjectWithCodeAnalysisRuleItemsAndGlobalError/TestProjectWithCodeAnalysisRuleItemsAndGlobalError.csproj
+++ b/test/TestProjectWithCodeAnalysisRuleItemsAndGlobalError/TestProjectWithCodeAnalysisRuleItemsAndGlobalError.csproj
@@ -1,0 +1,29 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+    <RunSqlCodeAnalysis>true</RunSqlCodeAnalysis>
+    <CodeAnalysisRules>+!*</CodeAnalysisRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRD0004</RuleId>
+      <Action>Suppress</Action>
+      <Explanation>test global error plus specific suppression</Explanation>
+    </CodeAnalysisRule>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+
+  <Target Name="WriteEffectiveCodeAnalysisRules" DependsOnTargets="ComputeCodeAnalysisRules">
+    <PropertyGroup>
+      <EffectiveCodeAnalysisRulesOutputFile Condition="'$(EffectiveCodeAnalysisRulesOutputFile)' == ''">$(IntermediateOutputPath)effective-code-analysis-rules.txt</EffectiveCodeAnalysisRulesOutputFile>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(EffectiveCodeAnalysisRulesOutputFile)"
+                      Overwrite="true"
+                      Lines="$(EffectiveCodeAnalysisRules)" />
+  </Target>
+</Project>

--- a/test/TestProjectWithCodeAnalysisRuleItemsAndProperty/TestProjectWithCodeAnalysisRuleItemsAndProperty.csproj
+++ b/test/TestProjectWithCodeAnalysisRuleItemsAndProperty/TestProjectWithCodeAnalysisRuleItemsAndProperty.csproj
@@ -1,0 +1,33 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SqlServerVersion>Sql150</SqlServerVersion>
+    <RunSqlCodeAnalysis>true</RunSqlCodeAnalysis>
+    <CodeAnalysisRules>-Smells.*;+!SqlServer.Rules.SRD0002</CodeAnalysisRules>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRD*</RuleId>
+      <Action>Suppress</Action>
+      <Explanation>test wildcard suppression</Explanation>
+    </CodeAnalysisRule>
+    <CodeAnalysisRule Include="_">
+      <RuleId>SqlServer.Rules.SRN0005</RuleId>
+      <Action>Error</Action>
+    </CodeAnalysisRule>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+
+  <Target Name="WriteEffectiveCodeAnalysisRules" DependsOnTargets="ComputeCodeAnalysisRules">
+    <PropertyGroup>
+      <EffectiveCodeAnalysisRulesOutputFile Condition="'$(EffectiveCodeAnalysisRulesOutputFile)' == ''">$(IntermediateOutputPath)effective-code-analysis-rules.txt</EffectiveCodeAnalysisRulesOutputFile>
+    </PropertyGroup>
+    <WriteLinesToFile File="$(EffectiveCodeAnalysisRulesOutputFile)"
+                      Overwrite="true"
+                      Lines="$(EffectiveCodeAnalysisRules)" />
+  </Target>
+</Project>


### PR DESCRIPTION
For issue #872, introduce `CodeAnalysisRule` items as an additive alternative to the existing `CodeAnalysisRules` property.

The new format improves readability for projects with many analyzer rule overrides, while remaining backward-compatible with the current semicolon-delimited property-based configuration.

Also adds README documentation and targeted tests covering:
- wildcard RuleId handling
- combination with existing CodeAnalysisRules
- +!* global error behavior
- suppression precedence on conflicts
 
