### PR TITLE
build(dacpactool): remove explicit C# LangVersion

### DIFF
--- a/src/DacpacTool/DacpacTool.csproj
+++ b/src/DacpacTool/DacpacTool.csproj
@@ -4,7 +4,6 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool</RootNamespace>
     <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-    <LangVersion>9.0</LangVersion>
     <AnalysisMode>all</AnalysisMode>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/test/DacpacTool.Tests/DacpacTool.Tests.csproj
+++ b/test/DacpacTool.Tests/DacpacTool.Tests.csproj
@@ -5,7 +5,6 @@
     <IsPackable>false</IsPackable>
     <AssemblyName>MSBuild.Sdk.SqlProj.DacpacTool.Tests</AssemblyName>
     <RootNamespace>MSBuild.Sdk.SqlProj.DacpacTool.Tests</RootNamespace>
-    <LangVersion>9.0</LangVersion>
     <NuGetAudit>false</NuGetAudit>
     <TestTfmsInParallel>false</TestTfmsInParallel>
   </PropertyGroup>


### PR DESCRIPTION
  Remove <LangVersion>9.0</LangVersion> from the DacpacTool app and test projects.

  guidance: https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version

  This is safe because these projects already target net8.0;net9.0;net10.0, and Microsoft recommends letting the default C# language version follow the target framework instead of pinning it manually. Keeping 9.0 artificially restricted the compiler below the language version associated with those TFMs; removing it restores the supported SDK default rather than opting into latest or preview.