### PR TITLE
ci: add test coverage reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   id-token: write   # required for GitHub OIDC
-  checks: write
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -21,6 +20,8 @@ jobs:
   build:
     # The type of runner that the job will run on
     runs-on: ubuntu-24.04
+    permissions:
+      checks: write
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -52,39 +53,52 @@ jobs:
 
     # Run tests for command line tool and collect coverage
     - name: dotnet test with coverage
+      id: tests
+      continue-on-error: true
       run: dotnet test ./test/DacpacTool.Tests/DacpacTool.Tests.csproj -c Release --results-directory ./artifacts/test-results --logger trx --collect:"XPlat Code Coverage"
 
     # Install ReportGenerator for coverage report generation
     - name: install reportgenerator
+      if: ${{ always() && !cancelled() }}
       run: dotnet tool install --tool-path . dotnet-reportgenerator-globaltool
 
     # Generate HTML and Markdown coverage reports
     - name: generate coverage report
+      if: ${{ always() && !cancelled() }}
       run: ./reportgenerator -reports:"./artifacts/test-results/**/coverage.cobertura.xml" -targetdir:"./artifacts/coverage-report" -reporttypes:"Html;MarkdownSummary"
 
     # Publish coverage summary to the GitHub Actions job summary
     - name: publish coverage summary
-      run: cat ./artifacts/coverage-report/Summary.md >> "$GITHUB_STEP_SUMMARY"
+      if: ${{ always() && !cancelled() }}
+      run: |
+        if [ -f ./artifacts/coverage-report/Summary.md ]; then
+          cat ./artifacts/coverage-report/Summary.md >> "$GITHUB_STEP_SUMMARY"
+        else
+          echo "Coverage summary not generated; skipping job summary publication."
+        fi
 
     # Upload HTML coverage report
     - name: upload coverage report
+      if: ${{ always() && !cancelled() }}
       uses: actions/upload-artifact@v7
       with:
         name: coverage-report
         path: ./artifacts/coverage-report
+        if-no-files-found: ignore
 
     # Upload raw test result files
     - name: upload test results
+      if: ${{ always() && !cancelled() }}
       uses: actions/upload-artifact@v7
-      if: (!cancelled())
       with:
         name: test-results
         path: ./artifacts/test-results/**/*
+        if-no-files-found: ignore
 
     # Publish TRX results to GitHub checks
     - name: publish test results
+      if: ${{ always() && !cancelled() }}
       uses: EnricoMi/publish-unit-test-result-action@v2
-      if: (!cancelled())
       with:
         check_name: "Unit Test Results"
         comment_mode: off
@@ -142,6 +156,10 @@ jobs:
       with:
         name: template-package
         path: ./src/MSBuild.Sdk.SqlProj.Templates/bin/Release/
+
+    - name: fail job if tests failed
+      if: ${{ always() && !cancelled() && steps.tests.outcome == 'failure' }}
+      run: exit 1
 
   # Run tests in parallel
   test:


### PR DESCRIPTION
  Update GitHub Actions workflow to surface test results and coverage

You can see them by [looking at the build summary](https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/actions/runs/23469908350?pr=885#summary-68290141506)

Example screenshot
<img width="5232" height="2943" alt="image" src="https://github.com/user-attachments/assets/fc6a7028-b5fb-495b-a5e9-008dbc5fa8c0" />

The `checks: write`, and the `EnricoMi/publish-unit-test-result-action@v2` gives us this
gives us this
<img width="631" height="385" alt="image" src="https://github.com/user-attachments/assets/83410a2f-ec2c-4823-a93a-ea9b96af2740" />

