### PR TITLE
feat: add .editorconfig support for SQL analyzer rule severity overrides

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,6 +112,10 @@ jobs:
     - name: dotnet build SDK
       run: dotnet build ./src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj -c Release
 
+    # Verify .editorconfig-backed analyzer rule overrides
+    - name: validate editorconfig rules
+      run: bash ./test/validate-editorconfig-rules.sh
+
     # Verify generated create scripts are copied to referencing project outputs
     - name: validate generated create script copy
       run: bash ./test/validate-generated-create-script-copy.sh

--- a/README.md
+++ b/README.md
@@ -626,6 +626,23 @@ A xml file with the analysis results is created in the output folder.
 
 The optional `CodeAnalysisRules` property allows you to disable individual rules or groups of rules for the entire project.
 
+The SDK also reads `.editorconfig` severity entries for SQL analysis rules from the project directory and its parent directories. Supported mappings are:
+
+- `dotnet_diagnostic.<Assembly>.<RuleId>.severity = error` to report that rule as an error
+- `dotnet_diagnostic.<Assembly>.<RuleId>.severity = none` to suppress that rule
+
+For example:
+
+```ini
+[*.sql]
+dotnet_diagnostic.SqlServer.Rules.SRD0006.severity = error
+dotnet_diagnostic.SqlServer.Rules.SRD0002.severity = none
+```
+
+Use the fully qualified rule name in `.editorconfig`, for example `SqlServer.Rules.SRD0006`. Non-qualified rule IDs are ignored with a warning so analyzer packages cannot conflict on the same short `RuleId`.
+
+The current implementation applies entries from `[*]`, `[*.*]`, `[*.sql]`, `[**.sql]`, and `[**/*.sql]` sections. If `.editorconfig`, and `CodeAnalysisRules`, are used, they are combined.
+
 Starting with version 3.0.0 of the SDK, you can also disable rules per file. Add a `StaticCodeAnalysis.SuppressMessages.xml` file to the project root, with contents similar to this:
 
 ```xml

--- a/src/DacpacTool/PackageAnalyzer.cs
+++ b/src/DacpacTool/PackageAnalyzer.cs
@@ -9,17 +9,20 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 {
     public sealed class PackageAnalyzer
     {
+        private const string EditorConfigFileName = ".editorconfig";
+        private const string DotNetDiagnosticPrefix = "dotnet_diagnostic.";
+        private const string SeveritySuffix = ".severity";
         private readonly IConsole _console;
-        private readonly HashSet<string> _ignoredRules = new();
-        private readonly HashSet<string> _ignoredRuleSets = new();
-        private readonly HashSet<string> _errorRuleSets = new();
-        private readonly char[] separator = new[] { ';' };
+        private readonly HashSet<string> _ignoredRules = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _ignoredRuleSets = new(StringComparer.OrdinalIgnoreCase);
+        private readonly HashSet<string> _errorRuleSets = new(StringComparer.OrdinalIgnoreCase);
+        private readonly string _rulesExpression;
+        private readonly char[] separator = [';'];
 
         public PackageAnalyzer(IConsole console, string rulesExpression)
         {
             _console = console ?? throw new ArgumentNullException(nameof(console));
-
-            BuildRuleLists(rulesExpression);
+            _rulesExpression = rulesExpression;
         }
 
         public void Analyze(TSqlModel model, FileInfo outputFile, FileInfo[] analyzers)
@@ -34,7 +37,6 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 var factory = new CodeAnalysisServiceFactory();
                 var settings = new CodeAnalysisServiceSettings();
 
-
                 if (analyzers.Length > 0)
                 {
                     settings.AssemblyLookupPath = string.Join(';', analyzers.Select(a => a.DirectoryName));
@@ -48,10 +50,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 {
                     _console.WriteLine("DacpacTool warning SQLPROJ0001: No additional well-known rules files found, consider adding more rules via PackageReference - see the readme here: https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/blob/master/README.md#static-code-analysis. You can ignore this warning by adding '<NoWarn>$(NoWarn);SQLPROJ0001</NoWarn>' to your project file.");
                 }
-                    
+
                 _console.WriteLine("Using analyzers: " + string.Join(", ", rules.Select(a => a.Namespace).Distinct()));
 
                 var projectDir = Environment.CurrentDirectory;
+                BuildRuleLists(projectDir, _rulesExpression);
                 var suppressorPath = Path.Combine(projectDir, ProjectProblemSuppressor.SuppressionFilename);
                 List<SuppressedProblemInfo> suppressedProblems = new();
 
@@ -68,15 +71,18 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                     }
                 }
 
+                var suppressedProblemKeys = suppressedProblems
+                    .Select(problem => BuildSuppressedProblemKey(projectDir, problem.Rule.RuleId, problem.SourceName))
+                    .ToHashSet(StringComparer.Ordinal);
+
                 if (_ignoredRules.Count > 0 
                     || _ignoredRuleSets.Count > 0
                     || suppressedProblems.Count > 0)
                 {
-                    service.SetProblemSuppressor(p => 
-                        suppressedProblems.Any(s => s.Rule.RuleId == p.Rule.RuleId
-                            && Path.Combine(projectDir, s.SourceName).Replace('\\', Path.AltDirectorySeparatorChar) == p.Problem.SourceName.Replace('\\', Path.AltDirectorySeparatorChar))
-                        || _ignoredRules.Contains(p.Rule.RuleId)
-                        || _ignoredRuleSets.Any(s => p.Rule.RuleId.StartsWith(s, StringComparison.OrdinalIgnoreCase)));
+                    service.SetProblemSuppressor(problem =>
+                        suppressedProblemKeys.Contains(BuildSuppressedProblemKey(projectDir, problem.Rule.RuleId, problem.Problem.SourceName))
+                        || _ignoredRules.Contains(problem.Rule.RuleId)
+                        || _ignoredRuleSets.Any(s => problem.Rule.RuleId.StartsWith(s, StringComparison.OrdinalIgnoreCase)));
                 }
 
                 var result = service.Analyze(model);
@@ -111,34 +117,383 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
 #pragma warning restore CA1031 // Do not catch general exception types
         }
 
-        private void BuildRuleLists(string rulesExpression)
+        private void BuildRuleLists(string projectDir, string rulesExpression)
         {
+            _ignoredRules.Clear();
+            _ignoredRuleSets.Clear();
+            _errorRuleSets.Clear();
+
+            var exactRuleActions = new Dictionary<string, RuleAction>(StringComparer.OrdinalIgnoreCase);
+            var prefixedSuppressions = new Dictionary<string, RuleAction>(StringComparer.OrdinalIgnoreCase);
+            var errorPatterns = new Dictionary<string, RuleAction>(StringComparer.OrdinalIgnoreCase);
+
+            foreach (var expression in LoadRuleExpressionsFromEditorConfig(projectDir))
+            {
+                ApplyRuleExpression(expression, exactRuleActions, prefixedSuppressions, errorPatterns);
+            }
+
             if (!string.IsNullOrWhiteSpace(rulesExpression))
             {
-                foreach (var rule in rulesExpression.Split(separator,
-                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                        .Where(rule => rule
-                            .StartsWith('-')
-                                && rule.Length > 1))
+                foreach (var expression in rulesExpression.Split(separator,
+                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                 {
-                    if (rule.Length > 2 && rule.EndsWith('*'))
+                    ApplyRuleExpression(expression, exactRuleActions, prefixedSuppressions, errorPatterns);
+                }
+            }
+
+            foreach (var exactRuleAction in exactRuleActions)
+            {
+                if (exactRuleAction.Value == RuleAction.Suppress)
+                {
+                    _ignoredRules.Add(exactRuleAction.Key);
+                }
+                else
+                {
+                    _errorRuleSets.Add(exactRuleAction.Key);
+                }
+            }
+
+            foreach (var prefixedSuppression in prefixedSuppressions.Where(p => p.Value == RuleAction.Suppress))
+            {
+                _ignoredRuleSets.Add(prefixedSuppression.Key);
+            }
+
+            foreach (var errorPattern in errorPatterns.Where(p => p.Value == RuleAction.Error))
+            {
+                _errorRuleSets.Add(errorPattern.Key);
+            }
+        }
+
+        private static void ApplyRuleExpression(
+            string expression,
+            IDictionary<string, RuleAction> exactRuleActions,
+            IDictionary<string, RuleAction> prefixedSuppressions,
+            IDictionary<string, RuleAction> errorPatterns)
+        {
+            if (string.IsNullOrWhiteSpace(expression))
+            {
+                return;
+            }
+
+            if (expression.Length > 1 && expression[0] == '-')
+            {
+                if (expression.Length > 2 && expression.EndsWith('*'))
+                {
+                    prefixedSuppressions[expression[1..^1]] = RuleAction.Suppress;
+                }
+                else
+                {
+                    exactRuleActions[expression[1..]] = RuleAction.Suppress;
+                }
+
+                return;
+            }
+
+            if (expression.StartsWith("+!", StringComparison.OrdinalIgnoreCase) && expression.Length > 2)
+            {
+                var errorPattern = expression[2..];
+                if (errorPattern.EndsWith('*'))
+                {
+                    errorPatterns[errorPattern] = RuleAction.Error;
+                }
+                else
+                {
+                    exactRuleActions[errorPattern] = RuleAction.Error;
+                }
+            }
+        }
+
+        private IEnumerable<string> LoadRuleExpressionsFromEditorConfig(string projectDir)
+        {
+            if (string.IsNullOrWhiteSpace(projectDir) || !Directory.Exists(projectDir))
+            {
+                yield break;
+            }
+
+            foreach (var severityOverride in LoadEditorConfigSeverityOverrides(projectDir))
+            {
+                if (!TryNormalizeEditorConfigRuleId(severityOverride.Key, out var normalizedRuleId))
+                {
+                    _console.WriteLine($"DacpacTool warning SQLPROJ0002: .editorconfig rule id '{severityOverride.Key}' must use a fully qualified rule name in the form '<AnalyzerNamespace>.<RuleId>'.");
+                    continue;
+                }
+
+                if (severityOverride.Value == RuleAction.Suppress)
+                {
+                    yield return "-" + normalizedRuleId;
+                }
+                else if (severityOverride.Value == RuleAction.Error)
+                {
+                    yield return "+!" + normalizedRuleId;
+                }
+            }
+        }
+
+        private static Dictionary<string, RuleAction> LoadEditorConfigSeverityOverrides(string projectDir)
+        {
+            var severityOverrides = new Dictionary<string, RuleAction>(StringComparer.OrdinalIgnoreCase);
+            var sqlFilePaths = EnumerateSqlFilePaths(projectDir);
+
+            foreach (var editorConfigPath in EnumerateEditorConfigFiles(projectDir))
+            {
+                MergeEditorConfigFile(editorConfigPath, projectDir, sqlFilePaths, severityOverrides);
+            }
+
+            return severityOverrides;
+        }
+
+        private static List<string> EnumerateSqlFilePaths(string projectDir)
+        {
+            if (string.IsNullOrWhiteSpace(projectDir) || !Directory.Exists(projectDir))
+            {
+                return [];
+            }
+
+            return Directory.EnumerateFiles(projectDir, "*.sql", SearchOption.AllDirectories)
+                .Select(filePath => Path.GetRelativePath(projectDir, filePath).Replace('\\', '/'))
+                .ToList();
+        }
+
+        private static Stack<string> EnumerateEditorConfigFiles(string projectDir)
+        {
+            var paths = new Stack<string>();
+            var currentDirectory = new DirectoryInfo(projectDir);
+
+            while (currentDirectory is not null)
+            {
+                var editorConfigPath = Path.Combine(currentDirectory.FullName, EditorConfigFileName);
+                if (File.Exists(editorConfigPath))
+                {
+                    paths.Push(editorConfigPath);
+                    if (HasRootSetting(editorConfigPath))
                     {
-                        _ignoredRuleSets.Add(rule[1..^1]);
+                        break;
+                    }
+                }
+
+                currentDirectory = currentDirectory.Parent;
+            }
+
+            return paths;
+        }
+
+        private static bool HasRootSetting(string editorConfigPath)
+        {
+            foreach (var line in File.ReadLines(editorConfigPath))
+            {
+                var trimmedLine = line.Trim();
+                if (IsCommentOrEmpty(trimmedLine) || trimmedLine.StartsWith('['))
+                {
+                    continue;
+                }
+
+                var separatorIndex = trimmedLine.IndexOf('=', StringComparison.Ordinal);
+                if (separatorIndex < 0)
+                {
+                    continue;
+                }
+
+                var key = trimmedLine[..separatorIndex].Trim();
+                var value = trimmedLine[(separatorIndex + 1)..].Trim();
+                if (key.Equals("root", StringComparison.OrdinalIgnoreCase)
+                    && value.Equals("true", StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void MergeEditorConfigFile(
+            string editorConfigPath,
+            string projectDir,
+            IReadOnlyCollection<string> sqlFilePaths,
+            IDictionary<string, RuleAction> severityOverrides)
+        {
+            var sectionApplies = true;
+            var editorConfigDirectory = Path.GetDirectoryName(editorConfigPath) ?? projectDir;
+
+            foreach (var line in File.ReadLines(editorConfigPath))
+            {
+                var trimmedLine = line.Trim();
+                if (IsCommentOrEmpty(trimmedLine))
+                {
+                    continue;
+                }
+
+                if (trimmedLine.StartsWith('[') && trimmedLine.EndsWith(']'))
+                {
+                    sectionApplies = SectionAppliesToSqlFiles(editorConfigDirectory, projectDir, sqlFilePaths, trimmedLine[1..^1].Trim());
+                    continue;
+                }
+
+                if (!sectionApplies)
+                {
+                    continue;
+                }
+
+                var separatorIndex = trimmedLine.IndexOf('=', StringComparison.Ordinal);
+                if (separatorIndex < 0)
+                {
+                    continue;
+                }
+
+                var key = trimmedLine[..separatorIndex].Trim();
+                var value = trimmedLine[(separatorIndex + 1)..].Trim();
+                if (!TryMapSeverityOverride(key, value, out var ruleId, out var ruleAction))
+                {
+                    continue;
+                }
+
+                severityOverrides[ruleId] = ruleAction;
+            }
+        }
+
+        private static bool TryMapSeverityOverride(string key, string value, out string ruleId, out RuleAction ruleAction)
+        {
+            ruleId = null;
+            ruleAction = default;
+
+            if (!key.StartsWith(DotNetDiagnosticPrefix, StringComparison.OrdinalIgnoreCase)
+                || !key.EndsWith(SeveritySuffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            var ruleIdLength = key.Length - DotNetDiagnosticPrefix.Length - SeveritySuffix.Length;
+            if (ruleIdLength <= 0)
+            {
+                return false;
+            }
+
+            ruleId = key.Substring(DotNetDiagnosticPrefix.Length, ruleIdLength);
+            if (value.Equals("none", StringComparison.OrdinalIgnoreCase))
+            {
+                ruleAction = RuleAction.Suppress;
+                return true;
+            }
+
+            if (value.Equals("error", StringComparison.OrdinalIgnoreCase))
+            {
+                ruleAction = RuleAction.Error;
+                return true;
+            }
+
+            return false;
+        }
+
+        private static bool TryNormalizeEditorConfigRuleId(string ruleId, out string normalizedRuleId)
+        {
+            normalizedRuleId = null;
+            if (string.IsNullOrWhiteSpace(ruleId))
+            {
+                return false;
+            }
+
+            if (!ruleId.Contains('.', StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            normalizedRuleId = ruleId;
+            return true;
+        }
+
+        private static bool SectionAppliesToSqlFiles(
+            string editorConfigDirectory,
+            string projectDir,
+            IReadOnlyCollection<string> sqlFilePaths,
+            string sectionPattern)
+        {
+            if (string.IsNullOrWhiteSpace(sectionPattern) || sqlFilePaths.Count == 0)
+            {
+                return false;
+            }
+
+            var normalizedPattern = sectionPattern.Replace('\\', '/');
+            var editorConfigRelativeDirectory = Path.GetRelativePath(projectDir, editorConfigDirectory).Replace('\\', '/');
+            if (editorConfigRelativeDirectory == ".")
+            {
+                editorConfigRelativeDirectory = string.Empty;
+            }
+
+            return sqlFilePaths.Any(sqlFilePath => PatternMatchesSqlFile(normalizedPattern, editorConfigRelativeDirectory, sqlFilePath));
+        }
+
+        private static bool PatternMatchesSqlFile(string sectionPattern, string editorConfigRelativeDirectory, string sqlFilePath)
+        {
+            var candidatePath = string.IsNullOrEmpty(editorConfigRelativeDirectory)
+                ? sqlFilePath
+                : $"{editorConfigRelativeDirectory.TrimEnd('/')}/{sqlFilePath}";
+
+            return IsEditorConfigMatch(sectionPattern, candidatePath)
+                || (!sectionPattern.Contains('/', StringComparison.Ordinal) && IsEditorConfigMatch(sectionPattern, Path.GetFileName(sqlFilePath)));
+        }
+
+        private static bool IsEditorConfigMatch(string pattern, string candidate)
+        {
+            var regexPattern = "^" + ConvertEditorConfigPatternToRegex(pattern) + "$";
+            return System.Text.RegularExpressions.Regex.IsMatch(candidate, regexPattern, System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+        }
+
+        private static string ConvertEditorConfigPatternToRegex(string pattern)
+        {
+            var builder = new System.Text.StringBuilder();
+
+            for (var index = 0; index < pattern.Length; index++)
+            {
+                var current = pattern[index];
+                if (current == '*')
+                {
+                    var isDoubleStar = index + 1 < pattern.Length && pattern[index + 1] == '*';
+                    if (isDoubleStar)
+                    {
+                        builder.Append(".*");
+                        index++;
                     }
                     else
                     {
-                        _ignoredRules.Add(rule[1..]);
+                        builder.Append("[^/]*");
                     }
+
+                    continue;
                 }
-                foreach (var rule in rulesExpression.Split(separator,
-                    StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                        .Where(rule => rule
-                            .StartsWith("+!", StringComparison.OrdinalIgnoreCase)
-                                && rule.Length > 2))
+
+                if (current == '?')
                 {
-                    _errorRuleSets.Add(rule[2..]);
+                    builder.Append("[^/]");
+                    continue;
                 }
+
+                if ("+()^$.{}[]|\\".Contains(current, StringComparison.Ordinal))
+                {
+                    builder.Append('\\');
+                }
+
+                builder.Append(current);
             }
+
+            return builder.ToString();
+        }
+
+        private static bool IsCommentOrEmpty(string line) =>
+            string.IsNullOrWhiteSpace(line)
+            || line.StartsWith('#')
+            || line.StartsWith(';');
+
+        private static string BuildSuppressedProblemKey(string projectDir, string ruleId, string sourceName) =>
+            $"{ruleId}|{NormalizeSourcePath(projectDir, sourceName)}";
+
+        private static string NormalizeSourcePath(string projectDir, string sourceName)
+        {
+            if (string.IsNullOrWhiteSpace(sourceName))
+            {
+                return string.Empty;
+            }
+
+            return Path.Combine(projectDir, sourceName)
+                .Replace('\\', Path.AltDirectorySeparatorChar);
         }
 
         private static string GetOutputFileName(FileInfo outputFile)
@@ -149,6 +504,12 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool
                 outputFileName = outputFile.FullName[..^7];
             }
             return outputFileName + ".CodeAnalysis.xml";
+        }
+
+        private enum RuleAction
+        {
+            Suppress,
+            Error,
         }
     }
 }

--- a/test/DacpacTool.Tests/PackageAnalyzerTests.cs
+++ b/test/DacpacTool.Tests/PackageAnalyzerTests.cs
@@ -12,10 +12,11 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
     [TestClass]
     public class PackageAnalyzerTests
     {
-        private const string SuppressionFileName = global::Microsoft.SqlServer.Dac.CodeAnalysis.ProjectProblemSuppressor.SuppressionFilename;
+        private const string SuppressionFileName = Microsoft.SqlServer.Dac.CodeAnalysis.ProjectProblemSuppressor.SuppressionFilename;
         private const string SuppressionFileNameMixedCaseRuleIds = "StaticCodeAnalysis.SuppressMessages.mixed-rule-id-casing.xml";
         // IDE0330: keep object here because this test project also targets net8.0.
         private static readonly object SuppressionFileLock = new();
+        private const string EditorConfigFileName = ".editorconfig";
         private readonly IConsole _console = new TestConsole();
 
         [TestMethod]
@@ -24,19 +25,19 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Arrange
             var testConsole = (TestConsole)_console;
             testConsole.Lines.Clear();
-            var result = BuildSimpleModel();
+            var (fileInfo, model) = BuildSimpleModel();
             var packageAnalyzer = new PackageAnalyzer(_console, null);
 
             // Act
-            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+            packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
             
             // Assert
             testConsole.Lines.Count.ShouldBe(16);
 
-            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
             testConsole.Lines.ShouldContain($"proc1.sql(1,47): Warning SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
             testConsole.Lines.ShouldContain($"proc1.sql(1,47): Warning SML005 : Smells : Avoid use of 'Select *'");
-            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
         }
 
         [TestMethod]
@@ -67,18 +68,18 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Arrange
             var testConsole = (TestConsole)_console;
             testConsole.Lines.Clear();
-            var result = BuildSimpleModel();
+            var (fileInfo, model) = BuildSimpleModel();
             var packageAnalyzer = new PackageAnalyzer(_console, "-SqlServer.Rules.SRD*");
 
             // Act
-            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+            packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
 
             // Assert
             testConsole.Lines.Count.ShouldBe(14);
 
-            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
             testConsole.Lines.Any(l => l.Contains("SRD")).ShouldBeFalse();
-            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
         }
 
         [TestMethod]
@@ -87,19 +88,19 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Arrange
             var testConsole = (TestConsole)_console;
             testConsole.Lines.Clear();
-            var result = BuildSimpleModel();
+            var (fileInfo, model) = BuildSimpleModel();
             var packageAnalyzer = new PackageAnalyzer(_console, "+!SqlServer.Rules.SRD0006");
 
             // Act
-            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+            packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
 
             // Assert
             testConsole.Lines.Count.ShouldBe(16);
 
-            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
             testConsole.Lines.ShouldContain($"proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
             testConsole.Lines.Count(l => l.Contains("Error ")).ShouldBe(1);
-            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
         }
 
         [TestMethod]
@@ -108,22 +109,189 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Arrange
             var testConsole = (TestConsole)_console;
             testConsole.Lines.Clear();
-            var result = BuildSimpleModel();
+            var (fileInfo, model) = BuildSimpleModel();
             var packageAnalyzer = new PackageAnalyzer(_console, "+!SqlServer.Rules.SRD*");
 
             // Act
-            packageAnalyzer.Analyze(result.model, result.fileInfo, CollectAssemblyPaths());
+            packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
 
             // Assert
             testConsole.Lines.Count.ShouldBe(16);
 
             testConsole.Lines.Count(l => l.Contains("Using analyzers: ")).ShouldBe(1);
-            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
             testConsole.Lines.ShouldNotContain("DacpacTool warning SQLPROJ0001: No additional well-known rules files found, consider adding more rules via PackageReference - see the readme here: https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/blob/master/README.md#static-code-analysis. You can ignore this warning by adding '<NoWarn>$(NoWarn);SQLPROJ0001</NoWarn>' to your project file.");
             testConsole.Lines.ShouldContain($"proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
             testConsole.Lines.ShouldContain($"-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.");
             testConsole.Lines.Count(l => l.Contains("): Error ")).ShouldBe(2);
-            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void IgnoresNonQualifiedEditorConfigRuleIds()
+        {
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var (fileInfo, model) = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, null);
+            var originalDirectory = Environment.CurrentDirectory;
+            var tempDirectory = CreateTemporaryProjectDirectory();
+
+            try
+            {
+                File.WriteAllText(Path.Combine(tempDirectory, "proc1.sql"), "-- test");
+                File.WriteAllText(
+                    Path.Combine(tempDirectory, EditorConfigFileName),
+                    """
+                    root = true
+
+                    [*.sql]
+                    dotnet_diagnostic.SRD0006.severity = error
+                    """);
+
+                lock (SuppressionFileLock)
+                {
+                    Directory.SetCurrentDirectory(tempDirectory);
+                    packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+
+            testConsole.Lines.ShouldContain(l => l.Contains("SQLPROJ0002") && l.Contains("SRD0006"));
+            testConsole.Lines.ShouldContain("proc1.sql(1,47): Warning SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithEditorConfigSeverityOverrides()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var (fileInfo, model) = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, null);
+            var originalDirectory = Environment.CurrentDirectory;
+            var tempDirectory = CreateTemporaryProjectDirectory();
+
+            try
+            {
+                File.WriteAllText(Path.Combine(tempDirectory, "proc1.sql"), "-- test");
+                File.WriteAllText(
+                    Path.Combine(tempDirectory, EditorConfigFileName),
+                    """
+                    root = true
+
+                    [*.sql]
+                    dotnet_diagnostic.SqlServer.Rules.SRD0006.severity = error
+                    dotnet_diagnostic.SqlServer.Rules.SRD0002.severity = none
+                    """);
+
+                lock (SuppressionFileLock)
+                {
+                    Directory.SetCurrentDirectory(tempDirectory);
+
+                    // Act
+                    packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain("proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
+            testConsole.Lines.Any(l => l.Contains("SRD0002")).ShouldBeFalse();
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithNestedEditorConfigSqlSection()
+        {
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var (fileInfo, model) = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, null);
+            var originalDirectory = Environment.CurrentDirectory;
+            var tempDirectory = CreateTemporaryProjectDirectory();
+
+            try
+            {
+                var sqlDirectory = Path.Combine(tempDirectory, "src", "StoredProcedures");
+                Directory.CreateDirectory(sqlDirectory);
+                File.WriteAllText(Path.Combine(sqlDirectory, "proc1.sql"), "-- test");
+                File.WriteAllText(
+                    Path.Combine(tempDirectory, EditorConfigFileName),
+                    """
+                    root = true
+
+                    [src/**/*.sql]
+                    dotnet_diagnostic.SqlServer.Rules.SRD0006.severity = error
+                    """);
+
+                lock (SuppressionFileLock)
+                {
+                    Directory.SetCurrentDirectory(tempDirectory);
+                    packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+
+            testConsole.Lines.ShouldContain("proc1.sql(1,47): Error SRD0006 : SqlServer.Rules : Avoid using SELECT *.");
+        }
+
+        [TestMethod]
+        public void RunsAnalyzer_WithCodeAnalysisRulesOverridingEditorConfigForSameRule()
+        {
+            // Arrange
+            var testConsole = (TestConsole)_console;
+            testConsole.Lines.Clear();
+            var (fileInfo, model) = BuildSimpleModel();
+            var packageAnalyzer = new PackageAnalyzer(_console, "-SqlServer.Rules.SRD0006;+!SqlServer.Rules.SRD0002");
+            var originalDirectory = Environment.CurrentDirectory;
+            var tempDirectory = CreateTemporaryProjectDirectory();
+
+            try
+            {
+                File.WriteAllText(Path.Combine(tempDirectory, "proc1.sql"), "-- test");
+                File.WriteAllText(
+                    Path.Combine(tempDirectory, EditorConfigFileName),
+                    """
+                    root = true
+
+                    [*.sql]
+                    dotnet_diagnostic.SqlServer.Rules.SRD0006.severity = error
+                    dotnet_diagnostic.SqlServer.Rules.SRD0002.severity = none
+                    """);
+
+                lock (SuppressionFileLock)
+                {
+                    Directory.SetCurrentDirectory(tempDirectory);
+
+                    // Act
+                    packageAnalyzer.Analyze(model, fileInfo, CollectAssemblyPaths());
+                }
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(originalDirectory);
+                Directory.Delete(tempDirectory, recursive: true);
+            }
+
+            // Assert
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
+            testConsole.Lines.Any(l => l.Contains("SRD0006")).ShouldBeFalse();
+            testConsole.Lines.ShouldContain("-1(1,1): Error SRD0002 : SqlServer.Rules : Table does not have a primary key.");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
         }
 
         [TestMethod]
@@ -132,20 +300,20 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             // Arrange
             var testConsole = (TestConsole)_console;
             testConsole.Lines.Clear();
-            var result = BuildSimpleModel();
+            var (fileInfo, model) = BuildSimpleModel();
             var packageAnalyzer = new PackageAnalyzer(_console, null);
 
             // Act
-            packageAnalyzer.Analyze(result.model, result.fileInfo, Array.Empty<FileInfo>());
+            packageAnalyzer.Analyze(model, fileInfo, []);
 
             // Assert
             testConsole.Lines.Count.ShouldBe(6);
 
             testConsole.Lines[1].ShouldBe("DacpacTool warning SQLPROJ0001: No additional well-known rules files found, consider adding more rules via PackageReference - see the readme here: https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/blob/master/README.md#static-code-analysis. You can ignore this warning by adding '<NoWarn>$(NoWarn);SQLPROJ0001</NoWarn>' to your project file.");
-            testConsole.Lines.ShouldContain($"Analyzing package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Analyzing package '{fileInfo.FullName}'");
             testConsole.Lines.Count(l => l.Contains("Using analyzers: ")).ShouldBe(1);
             testConsole.Lines.Count(l => l.Contains("): Error ")).ShouldBe(0);
-            testConsole.Lines.ShouldContain($"Successfully analyzed package '{result.fileInfo.FullName}'");
+            testConsole.Lines.ShouldContain($"Successfully analyzed package '{fileInfo.FullName}'");
         }
 
         [TestMethod]
@@ -177,7 +345,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
                     // Set the current directory.
                     Directory.SetCurrentDirectory(Path.Combine(Path.GetDirectoryName(typeof(PackageAnalyzerTests).Assembly.Location), "Suppression"));
                     // Act
-                    packageAnalyzer.Analyze(packageBuilder.Model, path, Array.Empty<FileInfo>());
+                    packageAnalyzer.Analyze(packageBuilder.Model, path, []);
                 }
                 finally
                 {
@@ -233,7 +401,7 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
                     File.Copy(mixedCaseSuppressionFile, originalSuppressionFile);
                     Directory.SetCurrentDirectory(suppressionDirectory);
                     testConsole.Lines.Clear();
-                    packageAnalyzer.Analyze(packageBuilder.Model, path, Array.Empty<FileInfo>());
+                    packageAnalyzer.Analyze(packageBuilder.Model, path, []);
 
                     // proc1.sql is suppressed by the correctly cased RuleId.
                     testConsole.Lines.Any(l => l.Contains("proc1.sql") && l.Contains("Warning SR0001 : Microsoft.Rules.Data")).ShouldBeFalse();
@@ -276,6 +444,13 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
             result.Add(new FileInfo(Path.Combine(path, "TSQLSmellSCA.dll")));
 
             return result.ToArray();
+        }
+
+        private static string CreateTemporaryProjectDirectory()
+        {
+            var tempDirectory = Path.Combine(Path.GetTempPath(), $"{nameof(PackageAnalyzerTests)}.{Guid.NewGuid():N}");
+            Directory.CreateDirectory(tempDirectory);
+            return tempDirectory;
         }
     }
 

--- a/test/TestProjectWithEditorConfigMatrix/.editorconfig
+++ b/test/TestProjectWithEditorConfigMatrix/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.sql]
+dotnet_diagnostic.SqlServer.Rules.SRD0068.severity = error
+dotnet_diagnostic.SqlServer.Rules.SRP0005.severity = none
+dotnet_diagnostic.SRD0002.severity = error
+dotnet_diagnostic.SRP0020.severity = none

--- a/test/TestProjectWithEditorConfigMatrix/Procedures/sp_Test.sql
+++ b/test/TestProjectWithEditorConfigMatrix/Procedures/sp_Test.sql
@@ -1,0 +1,5 @@
+CREATE PROCEDURE dbo.sp_Test
+AS
+BEGIN
+    SELECT Id FROM dbo.MyTable
+END

--- a/test/TestProjectWithEditorConfigMatrix/Tables/MyTable.sql
+++ b/test/TestProjectWithEditorConfigMatrix/Tables/MyTable.sql
@@ -1,0 +1,4 @@
+CREATE TABLE dbo.MyTable
+(
+    Id INT NOT NULL
+)

--- a/test/TestProjectWithEditorConfigMatrix/TestProjectWithEditorConfigMatrix.csproj
+++ b/test/TestProjectWithEditorConfigMatrix/TestProjectWithEditorConfigMatrix.csproj
@@ -1,0 +1,18 @@
+<Project>
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <SqlServerVersion>Sql160</SqlServerVersion>
+    <RunSqlCodeAnalysis>true</RunSqlCodeAnalysis>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="ErikEJ.DacFX.SqlServer.Rules" Version="3.2.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <Import Project="$(MSBuildThisFileDirectory)..\..\src\MSBuild.Sdk.SqlProj\Sdk\Sdk.targets" />
+</Project>

--- a/test/validate-editorconfig-rules.sh
+++ b/test/validate-editorconfig-rules.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Regression check for .editorconfig-backed SQL analyzer severity overrides.
+# This script builds the SDK first so the packaged DacpacTool under
+# src/MSBuild.Sdk.SqlProj/tools/* is up to date before the fixture projects run.
+#
+# Run locally from the repo root:
+#   bash ./test/validate-editorconfig-rules.sh
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+matrix_project="${repo_root}/test/TestProjectWithEditorConfigMatrix/TestProjectWithEditorConfigMatrix.csproj"
+
+matrix_log="$(mktemp)"
+
+cleanup() {
+  rm -f "${matrix_log}"
+  rm -rf \
+    "${repo_root}/test/TestProjectWithEditorConfigMatrix/bin" \
+    "${repo_root}/test/TestProjectWithEditorConfigMatrix/obj"
+}
+trap cleanup EXIT
+
+require_log_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if ! grep -F "${needle}" "${file}" >/dev/null; then
+    echo "Expected to find: ${needle}"
+    echo
+    cat "${file}"
+    exit 1
+  fi
+}
+
+require_log_not_contains() {
+  local needle="$1"
+  local file="$2"
+
+  if grep -F "${needle}" "${file}" >/dev/null; then
+    echo "Did not expect to find: ${needle}"
+    echo
+    cat "${file}"
+    exit 1
+  fi
+}
+
+run_and_capture() {
+  local log_file="$1"
+  shift
+
+  set +e
+  "$@" 2>&1 | tee "${log_file}"
+  local cmd_exit=${PIPESTATUS[0]}
+  set -e
+
+  return "${cmd_exit}"
+}
+
+cd "${repo_root}"
+
+echo "Building SDK package project so the packaged DacpacTool is current..."
+# Keep the packaged SDK tool current before building the test fixtures.
+dotnet build ./src/MSBuild.Sdk.SqlProj/MSBuild.Sdk.SqlProj.csproj -c Release -nologo
+
+# Qualified rule names in .editorconfig should:
+# - promote SRD0068 to an error
+# - suppress SRP0005 entirely
+echo "Building editorconfig matrix fixture..."
+if run_and_capture "${matrix_log}" dotnet build "${matrix_project}" -nologo; then
+  matrix_exit=0
+else
+  matrix_exit=$?
+fi
+
+if [[ "${matrix_exit}" -eq 0 ]]; then
+  echo "Expected the editorconfig matrix fixture to fail the build with SRD0068 as an error."
+  echo
+  cat "${matrix_log}"
+  exit 1
+fi
+
+echo "Checking qualified editorconfig entries..."
+require_log_contains "error SRD0068: SqlServer.Rules : Query statements should finish with a semicolon - ';'." "${matrix_log}"
+require_log_not_contains "SRP0005: SqlServer.Rules : SET NOCOUNT ON is recommended to be enabled in stored procedures and triggers." "${matrix_log}"
+
+echo "Checking invalid short rule ids were warned and ignored..."
+require_log_contains "SQLPROJ0002" "${matrix_log}"
+require_log_contains ".editorconfig rule id 'SRD0002' must use a fully qualified rule name" "${matrix_log}"
+require_log_contains ".editorconfig rule id 'SRP0020' must use a fully qualified rule name" "${matrix_log}"
+require_log_contains "warning SRD0002: SqlServer.Rules : Table does not have a primary key." "${matrix_log}"
+require_log_contains "warning SRP0020: SqlServer.Rules : Table does not have a clustered index." "${matrix_log}"
+
+echo "Editorconfig validation passed."


### PR DESCRIPTION
Per our discussion in PR https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/pull/874 @ErikEJ  suggested to try out an implementation with .editorconfig.

That is what this here PR is for. It is another way to address issue https://github.com/rr-wfm/MSBuild.Sdk.SqlProj/issues/872