### PR TITLE
docs(readme): document workaround for XML schema collection xsd files

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,33 @@ If you are using Visual Studio, to make files excluded from the package appear i
 
 Wildcards are supported for all nodes (`Content`, `None`, etc.). For example, `<None Include="Directory\**" />`.
 
+## XML schema collections (`.xsd`)
+
+`MSBuild.Sdk.SqlProj` does not currently process `.xsd` files added as build inputs the same way as classic `.sqlproj` projects.
+
+If your existing project uses an entry like this:
+
+```xml
+<ItemGroup>
+  <Build Include="XMLSchemaCollection1.xsd">
+    <RelationalSchema>dbo</RelationalSchema>
+    <XMLSchemaCollectionName>XMLSchemaCollection1</XMLSchemaCollectionName>
+  </Build>
+</ItemGroup>
+```
+
+use a `.sql` file instead that creates the XML schema collection directly:
+
+```sql
+CREATE XML SCHEMA COLLECTION [dbo].[XMLSchemaCollection1]
+    AS N'<?xml version="1.0" encoding="utf-16"?>
+<xs:schema id="XMLSchemaCollection1"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema">
+</xs:schema>';
+```
+
+In practice, the workaround is to copy the contents of the `.xsd` file into the `N'...'` string of a `CREATE XML SCHEMA COLLECTION` statement and include that `.sql` file in your project instead of the `.xsd` file.
+
 ## Use an existing database
 
 If you want to initialize your project with scripted objects from an existing database, you can do so with the following command:


### PR DESCRIPTION
This is for issue #861 where we will recommend the workaround with, where it seems there are no plans to implement full xsd support.