### PR TITLE
Emit ER diagram entities and FKs in deterministic order

### DIFF
--- a/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
+++ b/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
@@ -56,8 +56,9 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
 
             // Sort foreign keys for the same determinism reason as the tables above.
             foreach (var foreignKey in table.ForeignKeys
-                .OrderBy(fk => Sanitize($"{fk.PrincipalTable.Schema}.{fk.PrincipalTable.Name}"), StringComparer.Ordinal)
-                .ThenBy(fk => Sanitize(fk.Name ?? string.Empty), StringComparer.Ordinal))
+                .OrderBy(fk => fk.PrincipalTable.Schema, StringComparer.Ordinal)
+                .ThenBy(fk => fk.PrincipalTable.Name, StringComparer.Ordinal)
+                .ThenBy(fk => fk.Name ?? string.Empty, StringComparer.Ordinal))
             {
                 var relationship = "}o--|";
 

--- a/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
+++ b/src/DacpacTool/Diagram/DatabaseModelToMermaid.cs
@@ -27,7 +27,12 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
 
             sb.AppendLine("erDiagram");
 
-            foreach (var table in tables)
+            // Emit tables in a deterministic order. TSqlModel.GetObjects(...) does not guarantee a
+            // stable order and the Windows and Linux builds of DacFx enumerate differently, which
+            // would otherwise produce platform-dependent diagrams.
+            foreach (var table in tables
+                .OrderBy(t => t.Schema, StringComparer.Ordinal)
+                .ThenBy(t => t.Name, StringComparer.Ordinal))
             {
                 AddTable(sb, table);
             }
@@ -49,7 +54,10 @@ namespace MSBuild.Sdk.SqlProj.DacpacTool.Diagram
 
             sb.AppendLine("  }");
 
-            foreach (var foreignKey in table.ForeignKeys)
+            // Sort foreign keys for the same determinism reason as the tables above.
+            foreach (var foreignKey in table.ForeignKeys
+                .OrderBy(fk => Sanitize($"{fk.PrincipalTable.Schema}.{fk.PrincipalTable.Name}"), StringComparer.Ordinal)
+                .ThenBy(fk => Sanitize(fk.Name ?? string.Empty), StringComparer.Ordinal))
             {
                 var relationship = "}o--|";
 

--- a/test/DacpacTool.Tests/DatabaseModelToMermaidTests.cs
+++ b/test/DacpacTool.Tests/DatabaseModelToMermaidTests.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MSBuild.Sdk.SqlProj.DacpacTool.Diagram;
+using MSBuild.Sdk.SqlProj.DacpacTool.Diagram.Model;
+using Shouldly;
+
+namespace MSBuild.Sdk.SqlProj.DacpacTool.Tests
+{
+    [TestClass]
+    public class DatabaseModelToMermaidTests
+    {
+        [TestMethod]
+        public void CreateMermaid_SortsForeignKeysByRawPrincipalTableAndName()
+        {
+            var foreignKeyColumn = new SimpleColumn
+            {
+                Name = "PrincipalId",
+                StoreType = "int",
+            };
+
+            var dependentTable = new SimpleTable
+            {
+                Schema = "dbo",
+                Name = "Dependent",
+                Columns = { foreignKeyColumn },
+                ForeignKeys =
+                {
+                    new SimpleForeignKey
+                    {
+                        Name = "FK_Dependent_CustomerDetail",
+                        PrincipalTable = new SimpleTable { Schema = "dbo", Name = "CustomerDetail" },
+                        Columns = { foreignKeyColumn },
+                    },
+                    new SimpleForeignKey
+                    {
+                        Name = "FK_Dependent_Customer_Detail",
+                        PrincipalTable = new SimpleTable { Schema = "dbo", Name = "Customer Detail" },
+                        Columns = { foreignKeyColumn },
+                    },
+                },
+            };
+
+            var diagram = new DatabaseModelToMermaid(new List<SimpleTable> { dependentTable }).CreateMermaid();
+
+            diagram.IndexOf(": FK_Dependent_Customer_Detail", StringComparison.Ordinal).ShouldBeLessThan(
+                diagram.IndexOf(": FK_Dependent_CustomerDetail", StringComparison.Ordinal));
+        }
+    }
+}

--- a/test/ErDiagramHarnessProject/Expected/computed-column_erdiagram.md
+++ b/test/ErDiagramHarnessProject/Expected/computed-column_erdiagram.md
@@ -1,4 +1,4 @@
-```mermaid
+﻿```mermaid
 erDiagram
   "dbo.Entity" {
     EntityId int PK
@@ -13,6 +13,6 @@ erDiagram
     EntityId int FK
     EntityTypeCode computed(NULL) FK
   }
-  "dbo.SpecializedEntity" }o--o| "dbo.EntityTypeLookup" : FK_dbo_SpecializedEntity_dbo_EntityTypeLookup
   "dbo.SpecializedEntity" }o--o| "dbo.Entity" : FK_dbo_SpecializedEntity_EntityId_EntityTypeCode_dbo_Entity
+  "dbo.SpecializedEntity" }o--o| "dbo.EntityTypeLookup" : FK_dbo_SpecializedEntity_dbo_EntityTypeLookup
 ```

--- a/test/ErDiagramHarnessProject/Expected/hr_erdiagram.md
+++ b/test/ErDiagramHarnessProject/Expected/hr_erdiagram.md
@@ -1,4 +1,4 @@
-```mermaid
+﻿```mermaid
 erDiagram
   "hr.Employee" {
     EmployeeId int PK

--- a/test/ErDiagramHarnessProject/Expected/sales_erdiagram.md
+++ b/test/ErDiagramHarnessProject/Expected/sales_erdiagram.md
@@ -1,5 +1,9 @@
-```mermaid
+﻿```mermaid
 erDiagram
+  "dbo.Customer" {
+  }
+  "hr.Employee" {
+  }
   "sales.Invoice" {
     InvoiceId int PK
     CustomerId int FK
@@ -14,8 +18,4 @@ erDiagram
     DisplayValue computed(NULL) 
   }
   "sales.LineItem" }o--|| "sales.Invoice" : FK_sales_LineItem_sales_Invoice
-  "dbo.Customer" {
-  }
-  "hr.Employee" {
-  }
 ```

--- a/test/ErDiagramHarnessProject/Expected/special_erdiagram.md
+++ b/test/ErDiagramHarnessProject/Expected/special_erdiagram.md
@@ -1,4 +1,4 @@
-```mermaid
+﻿```mermaid
 erDiagram
   "dbo.Customer" {
     CustomerId int PK
@@ -8,6 +8,8 @@ erDiagram
     AnyColor computed(NULL) 
     IsColorSelected computed(NULL) 
   }
+  "sales.Invoice" {
+  }
   "sales.LineItem" {
     LineItemId int PK
     InvoiceId int FK
@@ -15,6 +17,4 @@ erDiagram
     DisplayValue computed(NULL) 
   }
   "sales.LineItem" }o--|| "sales.Invoice" : FK_sales_LineItem_sales_Invoice
-  "sales.Invoice" {
-  }
 ```


### PR DESCRIPTION
This fixes issue #951

TSqlModel.GetObjects(...) does not guarantee a stable enumeration order, and the Windows and Linux builds of Microsoft.SqlServer.DacFx return objects in different orders. As a result the generated mermaid ER diagrams differ by table/relationship ordering depending on the build OS, even though the model is identical. This makes the diagrams non-reproducible and breaks any check that diffs committed diagrams against a freshly built copy on a different platform.

Sort tables by (schema, name) and foreign keys by (principal table, name) using an ordinal comparer before emitting. Column order is left as-is since DacFx returns columns in a stable ordinal order.

Regenerate the ErDiagramHarnessProject golden files to match the new deterministic ordering.